### PR TITLE
Fix SendCommand

### DIFF
--- a/src/client/ClientRequest.ts
+++ b/src/client/ClientRequest.ts
@@ -277,7 +277,7 @@ const getUrl = (request: string, host: string, data: any, _data: any): string =>
 		case "StartServer": case "StopServer": case "KillServer": case "RestartServer":
 			return host + "/api/client/servers/" + _data + "/power";
 		case "SendCommand":
-			return host + "/api/client/servers/" + data + "/command";
+			return host + "/api/client/servers/" + _data + "/command";
 
 		// Backups
 		case "CreateBackup": case "ListBackups":


### PR DESCRIPTION
I was getting this error with the `SendCommand` function
```
code: 'NotFoundHttpException',
 status: '404',
detail: 'The requested resource could not be found on the server.'
```
After changing this line, it was fixed.